### PR TITLE
Code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master, develop ]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/nginx-cf-realip/security/code-scanning/1](https://github.com/RumenDamyanov/nginx-cf-realip/security/code-scanning/1)

To address the issue, insert a `permissions` block with the least required access for the workflow. As the workflow only needs to check out source code and does not interact with the repository in a way that requires writing (such as creating PRs, issues, etc.), the minimum needed is `contents: read`. Insert this block at the root of the workflow file (above `jobs:`), ensuring that it applies to all jobs within the workflow. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
